### PR TITLE
refactor(nanostores-qs): better type def

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const strStore = qsUtils.createSearchParamStore("str");
 // In React component
 function Str() {
   const str = useStore(strStore.$value);
-  //    ^? string
+  //    ^? string | undefined
 
   return (
     <input
@@ -65,11 +65,12 @@ function Str() {
 }
 
 // Number parameter with custom encoding/decoding
-const numStore = qsUtils.createSearchParamStore("num", {
-  decode: (v) => (!v ? "" : Number(v)),
-  encode: String,
-  defaultValue: "",
-});
+const numStore = qsUtils.createSearchParamStore("num", (def) =>
+  def({
+    decode: (v) => (!v ? "" : Number(v)),
+    defaultValue: "",
+  }),
+);
 
 function Num() {
   const num = useStore(numStore.$value);
@@ -122,18 +123,16 @@ By default, it uses `es-toolkit`'s `isEqual` function.
 ### Multiple Parameters
 
 ```tsx
-const filtersStore = qsUtils.createSearchParamsStore((defineSearchParam) => ({
-  search: defineSearchParam({ defaultValue: "" }),
-  category: defineSearchParam({ isArray: true }),
-  minPrice: defineSearchParam({
+const filtersStore = qsUtils.createSearchParamsStore((def) => ({
+  search: def({ defaultValue: "" }),
+  category: def({ isArray: true }),
+  minPrice: def({
     decode: Number,
-    encode: String,
-  }),
-  maxPrice: defineSearchParam({
+  }).setEncode(String),
+  maxPrice: def({
     decode: Number,
-    encode: String,
-  }),
-  sortBy: defineSearchParam({
+  }).setEncode(String),
+  sortBy: def({
     defaultValue: "newest",
   }),
 }));

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -39,17 +39,23 @@ const tabStore = urlSearchParamsUtils.createSearchParamStore("tab", {
   defaultValue: TabSchema.options[0],
 });
 
-const replaceStore = urlSearchParamsUtils.createSearchParamStore("replace", {
-  decode: (v) => v !== "false",
-  encode: (v) => (v ? undefined : "false"),
-  defaultValue: true,
-});
+const replaceStore = urlSearchParamsUtils.createSearchParamStore(
+  "replace",
+  (def) =>
+    def({
+      decode: (v) => v !== "false",
+      defaultValue: true,
+    }).setEncode((v) => (v ? undefined : "false")),
+);
 
-const keepHashStore = urlSearchParamsUtils.createSearchParamStore("keepHash", {
-  decode: (v) => v === "true",
-  encode: (v) => (v ? "true" : undefined),
-  defaultValue: false,
-});
+const keepHashStore = urlSearchParamsUtils.createSearchParamStore(
+  "keepHash",
+  (def) =>
+    def({
+      decode: (v) => v === "true",
+      defaultValue: false,
+    }).setEncode((v) => (v ? "true" : undefined)),
+);
 
 const qsUtils = createQsUtils({
   qs: {
@@ -58,42 +64,40 @@ const qsUtils = createQsUtils({
   },
 });
 
-const qsSearchParamsStore = qsUtils.createSearchParamsStore(
-  (defineSearchParam) => ({
-    qsSearch: defineSearchParam({}),
-    qsPage: defineSearchParam({
-      decode: IntegerParamSchema.parse,
-      encode: String,
-    }),
-    qsEnumArray: defineSearchParam({
-      isArray: true,
-      decode: z
-        .array(MultipleOptionsSchema.or(z.undefined().catch(undefined)))
-        .transform((arr) => arr.flatMap((v) => (v === undefined ? [] : [v])))
-        .parse,
-    }),
-    qsDate: defineSearchParam({
-      decode: z.string().transform(datetimeLocalToDate).parse,
-      encode: z.date().transform(dateToDatetimeLocal).parse,
-    }),
+const qsSearchParamsStore = qsUtils.createSearchParamsStore((def) => ({
+  qsSearch: undefined,
+  qsPage: def({
+    decode: IntegerParamSchema.parse,
+    encode: String,
   }),
-);
+  qsEnumArray: def({
+    isArray: true,
+    decode: z
+      .array(MultipleOptionsSchema.or(z.undefined().catch(undefined)))
+      .transform((arr) => arr.flatMap((v) => (v === undefined ? [] : [v])))
+      .parse,
+  }),
+  qsDate: def({
+    decode: z.string().transform(datetimeLocalToDate).parse,
+    encode: z.date().transform(dateToDatetimeLocal).parse,
+  }),
+}));
 
 const urlSearchParamsStore = urlSearchParamsUtils.createSearchParamsStore(
-  (defineSearchParam) => ({
-    urlSearch: defineSearchParam({}),
-    urlPage: defineSearchParam({
+  (def) => ({
+    urlSearch: undefined,
+    urlPage: def({
       decode: IntegerParamSchema.parse,
       encode: String,
     }),
-    urlEnumArray: defineSearchParam({
+    urlEnumArray: def({
       isArray: true,
       decode: z
         .array(MultipleOptionsSchema.or(z.undefined().catch(undefined)))
         .transform((arr) => arr.flatMap((v) => (v === undefined ? [] : [v])))
         .parse,
     }),
-    urlDate: defineSearchParam({
+    urlDate: def({
       decode: z.string().transform(datetimeLocalToDate).parse,
       encode: z.date().transform(dateToDatetimeLocal).parse,
     }),


### PR DESCRIPTION
Both `createSearchParamsStore` and `createSearchParamStore` now utilize the `def => dif({ ...config })` pattern to enhance developer experience through improved type inference. This change facilitates more accurate and predictable TypeScript support, particularly when dealing with complex configuration objects, resulting in a more streamlined and robust API design.

# Copilot

This pull request refactors the `createSearchParamStore` and `createSearchParamsStore` APIs to simplify their usage and improve code readability. The changes primarily involve replacing the `defineSearchParam` parameter with a shorter `def` function and introducing a new `.setEncode()` method for encoding customization. Additionally, the updates ensure better handling of default values and undefined states.

### API Simplifications and Enhancements:
* Updated `createSearchParamStore` to use a shorthand `def` function for parameter definitions and introduced `.setEncode()` for setting custom encoders. This improves readability and reduces boilerplate. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R135); `packages/demo/src/App.tsx` [[3]](diffhunk://#diff-ca61a133de83b59fe480a31ac3a5ca7d5754226ede9a6e97c6f8910a9c174dd0L42-R58)
* Replaced `defineSearchParam` with `def` in `createSearchParamsStore` to streamline the API and improve consistency across examples. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R135); `packages/demo/src/App.tsx` [[2]](diffhunk://#diff-ca61a133de83b59fe480a31ac3a5ca7d5754226ede9a6e97c6f8910a9c174dd0L61-R100)

### Improved Type Handling:
* Adjusted the `useStore` example to reflect that the value returned from `createSearchParamStore` can now be `string | undefined` instead of just `string`. (`README.md` [README.mdL55-R55](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55))