### PR TITLE
feat(nanostores-qs): force update option

### DIFF
--- a/packages/nanostores-qs/src/main.ts
+++ b/packages/nanostores-qs/src/main.ts
@@ -206,6 +206,7 @@ namespace createQsUtils {
   export interface UpdateOptions {
     replace?: boolean;
     keepHash?: boolean;
+    force?: boolean;
     state?: Parameters<typeof history.pushState>[0];
     unused?: Parameters<typeof history.pushState>[1];
   }
@@ -448,8 +449,13 @@ function createQsUtils<
     ) => {
       const state = updateOptions?.state ?? {};
       const unused = updateOptions?.unused ?? "";
+      const force = updateOptions?.force ?? false;
       const replace = updateOptions?.replace ?? false;
       const keepHash = updateOptions?.keepHash ?? false;
+      const currentValue = $values.get();
+      if (!force && isEqual(currentValue, values)) {
+        return;
+      }
       const qsRecord = $qs.get();
       const failedEncodeKeys: Array<keyof TValues> = [];
       const nextEncodedValues = Object.fromEntries(

--- a/packages/nanostores-qs/src/main.ts
+++ b/packages/nanostores-qs/src/main.ts
@@ -206,6 +206,10 @@ namespace createQsUtils {
   export interface UpdateOptions {
     replace?: boolean;
     keepHash?: boolean;
+    /**
+     * If true, forces the update to proceed even if the new value is the same as the current value.
+     * Defaults to `false`.
+     */
     force?: boolean;
     state?: Parameters<typeof history.pushState>[0];
     unused?: Parameters<typeof history.pushState>[1];


### PR DESCRIPTION
`nanostores-qs` now uses the `isEqual` function to check whether the state has actually changed when `update` is called—unless the `force` option is explicitly set.

# Copilot

This pull request introduces a new `force` option to the `UpdateOptions` interface in the `createQsUtils` utility, allowing users to bypass equality checks and enforce updates. The main changes include updates to the interface and the logic handling updates.

### Enhancements to `createQsUtils`:

* [`packages/nanostores-qs/src/main.ts`](diffhunk://#diff-e092877a51438ad62bed77079d39b1aae5c732052651a02426e865b50dc8e287R209): Added a `force` property to the `UpdateOptions` interface to provide an option for forcing updates.
* [`packages/nanostores-qs/src/main.ts`](diffhunk://#diff-e092877a51438ad62bed77079d39b1aae5c732052651a02426e865b50dc8e287R452-R458): Updated the `createQsUtils` function to include the `force` option in the logic. If `force` is `false` and the current value equals the new value, the update is skipped, improving efficiency.