### PR TITLE
fix(nanostores-qs): skip for ssr

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ function Str() {
 
   return (
     <input
-      value={str}
+      value={str ?? ""}
       onChange={(e) => {
         strStore.update(e.target.value);
       }}

--- a/packages/nanostores-qs/src/main.ts
+++ b/packages/nanostores-qs/src/main.ts
@@ -3,6 +3,9 @@ import { isEqual, isNil, mapValues } from "es-toolkit";
 import { atom, computed } from "nanostores";
 
 function getSearch() {
+  if (typeof window === "undefined") {
+    return "";
+  }
   return window.location.search;
 }
 
@@ -333,7 +336,9 @@ function createQsUtils<
     if ($internalSearch.get() === search) return;
     $internalSearch.set(search);
   }
-  {
+  (() => {
+    if (typeof window === "undefined") return;
+
     // Listen to popstate and pushState/replaceState
 
     window.addEventListener("popstate", updateSearch);
@@ -352,7 +357,7 @@ function createQsUtils<
       if (destroyed) return;
       updateSearch();
     };
-  }
+  })();
   const defaultItemConfig = {
     isArray: false,
     defaultValue: undefined,


### PR DESCRIPTION
fix #7 

Skip for SSR with checking the typeof window

# Copilot

This pull request includes several changes aimed at improving code robustness and handling edge cases. The most important updates include adding nullish coalescing to prevent potential issues with undefined values, ensuring compatibility with server-side rendering (SSR) environments, and improving event listener management.

### Improvements to input handling:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59): Updated the `value` attribute in the input element to use the nullish coalescing operator (`str ?? ""`) to ensure it defaults to an empty string if `str` is undefined or null.

### Enhancements for SSR compatibility:
* [`packages/nanostores-qs/src/main.ts`](diffhunk://#diff-e092877a51438ad62bed77079d39b1aae5c732052651a02426e865b50dc8e287R6-R8): Added a check for `typeof window === "undefined"` in the `getSearch` function to return an empty string when running in SSR environments.

### Event listener management:
* [`packages/nanostores-qs/src/main.ts`](diffhunk://#diff-e092877a51438ad62bed77079d39b1aae5c732052651a02426e865b50dc8e287L336-R341): Wrapped the logic for adding event listeners inside an immediately invoked function expression (IIFE) to ensure it only executes in browser environments. This includes checking for `typeof window === "undefined"` before adding `popstate` and `pushState/replaceState` listeners. [[1]](diffhunk://#diff-e092877a51438ad62bed77079d39b1aae5c732052651a02426e865b50dc8e287L336-R341) [[2]](diffhunk://#diff-e092877a51438ad62bed77079d39b1aae5c732052651a02426e865b50dc8e287L355-R360)

