### PR TITLE
fix(nanostores-qs): improve URL construction

### DIFF
--- a/packages/nanostores-qs/src/main.ts
+++ b/packages/nanostores-qs/src/main.ts
@@ -508,7 +508,7 @@ function createQsUtils<
       const stringified = qs.stringify(nextQsValues);
       const nextSearch = !stringified ? "" : `?${stringified}`;
       const currentHash = window.location.hash;
-      const url = nextSearch + (keepHash ? currentHash : "") || ".";
+      const url = window.location.pathname + (nextSearch || "") + (keepHash ? currentHash : "");
       if (replace) {
         history.replaceState(state, unused, url);
       } else {


### PR DESCRIPTION
Ensure correct URL assembly in `createQsUtils`, especially when `pathname` lacks a trailing slash and `keepHash` is true. This improves handling of search parameter updates